### PR TITLE
Fix rewrites feature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ module.exports = function koaFallbackApiMiddleware(options) {
       var match = parsedUrl.pathname.match(rewrite.from);
       if (match !== null) {
         rewriteTarget = evaluateRewriteRule(parsedUrl, match, rewrite.to);
-        logger('Rewriting', req.method, req.url, 'to', rewriteTarget);
+        logger('Rewriting', method, reqUrl, 'to', rewriteTarget);
         this.url = rewriteTarget;
         yield * next;
       }


### PR DESCRIPTION
The `rewrites` feature was failing for me anytime I specified a rewrite, I was able to get it working by correcting what appears to be a typo in a log statement. I am submitting the fix in this PR which will allow usages such as the following example to start working:

```
historyApiFallback({
  rewrites: [
    { from: /\/soccer/, to: '/soccer.html'}
  ]
});
```