### PR TITLE
migrate to koa v3.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,19 +32,19 @@ module.exports = function koaFallbackApiMiddleware(options) {
   options = options || {};
   var logger = getLogger(options);
 
-  return function * (next) {
-    var headers = this.headers,
-      reqUrl = this.url,
-      method = this.method;
+  return function (ctx, next) {
+    var headers = ctx.headers,
+      reqUrl = ctx.url,
+      method = ctx.method;
 
-    if (this.method !== 'GET') {
+    if (ctx.method !== 'GET') {
       logger(
         'Not rewriting',
         method,
         reqUrl,
         'because the method is not GET.'
       );
-      yield * next;
+      return next();
     } else if (!headers || typeof headers.accept !== 'string') {
       logger(
         'Not rewriting',
@@ -52,7 +52,7 @@ module.exports = function koaFallbackApiMiddleware(options) {
         reqUrl,
         'because the client did not send an HTTP accept header.'
       );
-      yield * next;
+      return next();
     } else if (headers.accept.indexOf('application/json') === 0) {
       logger(
         'Not rewriting',
@@ -60,7 +60,7 @@ module.exports = function koaFallbackApiMiddleware(options) {
         reqUrl,
         'because the client prefers JSON.'
       );
-      yield * next;
+      return next();
     } else if (!acceptsHtml(headers.accept)) {
       logger(
         'Not rewriting',
@@ -68,7 +68,7 @@ module.exports = function koaFallbackApiMiddleware(options) {
         reqUrl,
         'because the client does not accept HTML.'
       );
-      yield * next;
+      return next();
     }
 
     var parsedUrl = url.parse(reqUrl);
@@ -82,8 +82,8 @@ module.exports = function koaFallbackApiMiddleware(options) {
       if (match !== null) {
         rewriteTarget = evaluateRewriteRule(parsedUrl, match, rewrite.to);
         logger('Rewriting', method, reqUrl, 'to', rewriteTarget);
-        this.url = rewriteTarget;
-        yield * next;
+        ctx.url = rewriteTarget;
+        return next();
       }
     }
 
@@ -94,13 +94,13 @@ module.exports = function koaFallbackApiMiddleware(options) {
         reqUrl,
         'because the path includes a dot (.) character.'
       );
-      yield * next;
+      return next();
     }
 
     rewriteTarget = options.index || '/index.html';
     logger('Rewriting', method, reqUrl, 'to', rewriteTarget);
-    this.url = rewriteTarget;
+    ctx.url = rewriteTarget;
 
-    yield * next;
+    return next();
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "koa-history-api-fallback",
+  "version": "0.2.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
## Why

Using the old version show this warning: 

```bash
koa deprecated Support for generators will be removed in v3. See the documentation for examples of how to convert old middleware https://github.com/koajs/koa/blob/master/docs/migration.md src\app.js:32:5
```

## Migration

Convert the old middleware to the new one:

```javascript
// Old
function *(next) {
  const url = this.url
  // ...
  yield next;
}
// New
function (ctx, next) {
  const url = ctx.url
  // ...
  return next();
}
```